### PR TITLE
Adding ability to send emails for user confirmation/password reset/change email

### DIFF
--- a/lib/manatee/accounts/user_notifier.ex
+++ b/lib/manatee/accounts/user_notifier.ex
@@ -1,73 +1,30 @@
 defmodule Manatee.Accounts.UserNotifier do
-  # For simplicity, this module simply logs messages to the terminal.
-  # You should replace it by a proper email or notification tool, such as:
-  #
-  #   * Swoosh - https://hexdocs.pm/swoosh
-  #   * Bamboo - https://hexdocs.pm/bamboo
-  #
-  defp deliver(to, body) do
-    require Logger
-    Logger.debug(body)
-    {:ok, %{to: to, body: body}}
+  alias Manatee.Emails
+  alias Manatee.Mailer
+
+  defp deliver(%Bamboo.Email{} = email) do
+    Mailer.deliver_now(email)
+    {:ok, %{to: email.to, body: email.html_body}}
   end
 
   @doc """
   Deliver instructions to confirm account.
   """
   def deliver_confirmation_instructions(user, url) do
-    deliver(user.email, """
-
-    ==============================
-
-    Hi #{user.email},
-
-    You can confirm your account by visiting the URL below:
-
-    #{url}
-
-    If you didn't create an account with us, please ignore this.
-
-    ==============================
-    """)
+    deliver(Emails.welcome_email(%{email: user.email, url: url}))
   end
 
   @doc """
   Deliver instructions to reset a user password.
   """
   def deliver_reset_password_instructions(user, url) do
-    deliver(user.email, """
-
-    ==============================
-
-    Hi #{user.email},
-
-    You can reset your password by visiting the URL below:
-
-    #{url}
-
-    If you didn't request this change, please ignore this.
-
-    ==============================
-    """)
+    deliver(Emails.reset_password_email(%{email: user.email, url: url}))
   end
 
   @doc """
   Deliver instructions to update a user email.
   """
   def deliver_update_email_instructions(user, url) do
-    deliver(user.email, """
-
-    ==============================
-
-    Hi #{user.email},
-
-    You can change your email by visiting the URL below:
-
-    #{url}
-
-    If you didn't request this change, please ignore this.
-
-    ==============================
-    """)
+    deliver(Emails.update_email_email(%{email: user.email, url: url}))
   end
 end

--- a/lib/manatee/emails.ex
+++ b/lib/manatee/emails.ex
@@ -4,13 +4,42 @@ defmodule Manatee.Emails do
 
   @from "noreply@manatee.valravn.us"
 
-  def welcome_email(%{email: email}) do
+  def welcome_email(%{email: email, url: url}) do
     base_email()
     |> subject("Welcome!")
     |> to(email)
+    |> assign(:email, email)
+    |> assign(:url, url)
     |> render("welcome.html",
       title: "Thank you for signing up",
       preheader: "Thank you for signing up to the app."
+    )
+    |> premail()
+  end
+
+  def reset_password_email(%{email: email, url: url}) do
+    base_email()
+    |> subject("Reset your password")
+    |> to(email)
+    |> assign(:email, email)
+    |> assign(:url, url)
+    |> render("reset_password.html",
+      title: "Reset your password",
+      preheader: "Reset your password in Lawn Manatee"
+    )
+    |> premail()
+  end
+
+  # Called when a user wants to update their email
+  def update_email_email(%{email: email, url: url}) do
+    base_email()
+    |> subject("Change your email")
+    |> to(email)
+    |> assign(:email, email)
+    |> assign(:url, url)
+    |> render("change_email.html",
+      title: "Change your email",
+      preheader: "Change your email in Lawn Manatee"
     )
     |> premail()
   end

--- a/lib/manatee_web/templates/email/change_email.html.eex
+++ b/lib/manatee_web/templates/email/change_email.html.eex
@@ -1,0 +1,11 @@
+==============================
+
+Hi #{@email},
+
+You can change your email by visiting the URL below:
+
+#{@url}
+
+If you didn't request this change, please ignore this.
+
+==============================

--- a/lib/manatee_web/templates/email/reset_password.html.eex
+++ b/lib/manatee_web/templates/email/reset_password.html.eex
@@ -1,0 +1,11 @@
+ ==============================
+
+ Hi #{@email},
+
+ You can reset your password by visiting the URL below:
+
+ #{@url}
+
+ If you didn't request this change, please ignore this.
+
+ ==============================

--- a/lib/manatee_web/templates/email/welcome.html.eex
+++ b/lib/manatee_web/templates/email/welcome.html.eex
@@ -1,1 +1,11 @@
-<p>Thanks for joining</p>
+    ==============================
+
+    Hi #{@email},
+
+    You can confirm your account by visiting the URL below:
+
+    #{@url}
+
+    If you didn't create an account with us, please ignore this.
+
+    ==============================


### PR DESCRIPTION
After some troubleshooting, it looks like our UserNotifier was just logging out instead of sending emails.  I have this tweaked to use the Manatee.Mailer to send emails.